### PR TITLE
Fix Clean_name() to replace dots with underscores instead of erasing

### DIFF
--- a/src/SOFIE_core/src/SOFIE_common.cxx
+++ b/src/SOFIE_core/src/SOFIE_common.cxx
@@ -394,6 +394,7 @@ void UTILITY::UnidirectionalBroadcast(const std::vector<bool> & data, const std:
 std::string UTILITY::Clean_name(std::string input_tensor_name){
    std::string s (input_tensor_name);
    std::replace( s.begin(), s.end(), '-', '_');
+   std::replace( s.begin(), s.end(), '.', '_'); 
    // replace all non-alpohanumeric character except for "_"
    s.erase(std::remove_if(s.begin(), s.end(), []( char const& c ) -> bool { return !std::isalnum(c) && c != '_'; } ), s.end());
    return s;


### PR DESCRIPTION
Clean_name() in SOFIE_common.cxx erases dot characters from tensor names instead of replacing them with a safe character. This causes tensor name collisions when parsing TorchScript models whose ONNX graphs contain dotted intermediate names (e.g., 'input.1' and 'input1' both map to 'input1').

Add std::replace for '.' -> '_' consistent with existing '-' -> '_' treatment. This makes 'input.1' -> 'input_1' (distinct from 'input1').

Got this issue during testing of root-project/root#21528.

Reported in root-project/root#21527.